### PR TITLE
Create CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(COMPONENT_SRCDIRS
+        "src"
+        )
+
+set(COMPONENT_ADD_INCLUDEDIRS
+        "src"
+        )
+
+# Arduino-ESP32 core https://github.com/espressif/arduino-esp32
+set(COMPONENT_REQUIRES
+        "arduino-esp32"
+        )
+
+register_component()


### PR DESCRIPTION
This will allow users using CMake toolchains (like myself) to include this as a component.

For most, this may not be useful, but CMake is how I use Jetbrain's CLion to work with the ESP-IDF environment. This allows me to put the repo in my components folder, and import it automagically